### PR TITLE
Implement 2-stage submission workflow with auto final merge

### DIFF
--- a/.github/workflows/auto-final-merge.yml
+++ b/.github/workflows/auto-final-merge.yml
@@ -1,0 +1,70 @@
+name: Auto Final Merge
+on:
+  push:
+    tags:
+      - 'final-*'
+
+jobs:
+  auto-merge-to-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Find approved PR for this branch
+        id: find-pr
+        run: |
+          # タグが付いたブランチを特定
+          TAG_COMMIT=$(git rev-parse HEAD)
+          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | grep -v HEAD | head -1 | sed 's/origin\///' | xargs)
+          
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "❌ Cannot determine branch for this tag"
+            exit 1
+          fi
+          
+          echo "🔍 Checking for approved PR from branch: $BRANCH_NAME"
+          
+          # そのブランチから main への承認済みPRを検索
+          PR_NUMBER=$(gh pr list --state open --base main --head "$BRANCH_NAME" --json number,reviews --jq '.[] | select(.reviews | map(.state) | contains(["APPROVED"])) | .number')
+          
+          if [ -n "$PR_NUMBER" ]; then
+            echo "approved_pr=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "✅ Found approved PR #$PR_NUMBER from branch $BRANCH_NAME"
+          else
+            echo "❌ No approved PR found for branch $BRANCH_NAME"
+            echo "Please ensure:"
+            echo "1. PR from $BRANCH_NAME to main exists"
+            echo "2. PR has been approved by faculty"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Auto merge approved PR
+        run: |
+          PR_NUMBER=${{ steps.find-pr.outputs.approved_pr }}
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          
+          # PRを自動マージ
+          gh pr merge $PR_NUMBER --merge --delete-branch
+          
+          echo "✅ Automatically merged PR #$PR_NUMBER to main"
+          echo "🎓 Final submission complete with tag: $TAG_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create release
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          gh release create $TAG_NAME --title "Final Submission: $TAG_NAME" --notes "🎓 Automatically created for final submission
+
+Tag: \`$TAG_NAME\`
+Date: $(date)
+Status: Merged to main branch
+
+This release represents the final submitted version of the thesis." --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -172,30 +172,14 @@ def hello_world():
 
 ## 🔍 PDF 生成・確認
 
-### VS Code 内
+### VS Code 内での操作
 
 1. ▷ ボタン（Build LaTeX project）をクリック
 2. 🔍 ボタン（View LaTeX PDF）でプレビュー
 
-### コマンド
-
-#### 卒業論文
-```bash
-# PDF 生成
-latexmk -pv sotsuron.tex
-
-# 概要生成
-latexmk -pv gaiyou.tex
-```
-
-#### 修士論文
-```bash
-# PDF 生成
-latexmk -pv thesis.tex
-
-# 概要生成
-latexmk -pv abstract.tex
-```
+**対象ファイル**:
+- **卒業論文**: `sotsuron.tex`（本体）、`gaiyou.tex`（概要）
+- **修士論文**: `thesis.tex`（本体）、`abstract.tex`（概要）
 
 ## 🆘 困った時は
 
@@ -228,19 +212,34 @@ latexmk -pv abstract.tex
 - **VS Code LaTeX**: [latex-workshop.github.io](https://github.com/James-Yu/LaTeX-Workshop)
 - **textlint**: 日本語校正ツール
 
-## 🎓 提出について
+## 🎓 論文提出について
 
-### 最終提出時
+### 論文提出許可時
 
-1. 最終稿のPRを教員が承認
-2. 自分で最終稿PRをクローズ
-3. 教員からOKが出たら `submit` タグを作成
-4. 印刷版も忘れずに提出
+教員から「論文提出OK」の許可が出たら：
+
+1. **提出版にタグを付与**
+   
+   GitHub Desktop で：
+   - `History` で最新コミットを右クリック
+   - `Create Tag...` をクリック
+   - `Name` に **submit** と入力
+   - `Create Tag` → `Push origin`
+
+2. **概要執筆の開始**
+   - 教員の指示に従って概要 (`gaiyou.tex` または `abstract.tex`) の執筆を開始
+   - `abstract-1st` ブランチから開始（詳細は [WRITING-GUIDE.md](WRITING-GUIDE.md) 参照）
 
 ### 提出形式
 
-- **電子版**: GitHub リポジトリ
+- **電子版**: GitHub リポジトリ（submit タグ版）
 - **印刷版**: 学科規定に従って製本・提出
+
+### 注意点
+
+- **submit タグ**: 論文本体の提出版をマーク
+- **概要執筆**: submit タグ後、教員指示で概要執筆開始
+- **以降の手順**: 概要完成後の手順は教員から口頭で説明されます
 
 ---
 

--- a/WRITING-GUIDE.md
+++ b/WRITING-GUIDE.md
@@ -239,17 +239,46 @@ Git の詳しい知識は必要ありません。GitHub Desktop の操作だけ�
 3. PR作成時のタイトル: `abstract-1st` など
 4. 次稿は自動作成されたブランチで継続
 
-### 7. 最終提出
+### 7. 論文提出
 
-教員からOKの返事が来たら：
+教員から「論文提出OK」の許可が出たら：
 
-1. **提出版にタグを付与**
-   - GitHub Desktop の `History` で最新の履歴を右クリック
+#### 7.1 提出版へのタグ付与
+
+1. **submit tagを作成**
+   
+   GitHub Desktop で：
+   - `History` で最新コミットを右クリック
    - `Create Tag...` をクリック
    - `Name` に **submit** と入力
-   - `Create Tag` → `Push origin` でタグをプッシュ
+   - `Create Tag` → `Push origin`
 
 2. **印刷物の提出** も忘れずに実施
+
+#### 7.2 概要執筆の準備
+
+submit タグ作成後、教員の指示で概要執筆を開始します：
+
+1. **概要用ブランチの作成**
+   - GitHub Desktop で `New Branch`
+   - 名前: `abstract-1st`
+   - ベース: **submit タグを作成したブランチ**
+   - `Create branch` → `Publish branch`
+
+2. **概要の執筆**
+   - 概要ファイル（`gaiyou.tex` または `abstract.tex`）を編集
+   - 論文本体と同様にcommit & push
+   - PR作成時のタイトル: `abstract-1st`
+
+3. **以降の流れ**
+   - 概要の添削・修正を繰り返し
+   - 概要完成後の手順は教員から口頭で説明されます
+
+#### 7.3 submit tag の注意点
+
+- **提出マーク**: submit タグは論文本体の提出版を示します
+- **概要執筆**: submit タグ後、概要執筆に移行
+- **次の段階**: 概要完成後の手順は別途教員から指示されます
 
 ## よくある質問
 


### PR DESCRIPTION
## Summary

学生の論文提出プロセスを2段階に分離し、最終提出時の完全自動化を実現します。

### Major Changes

#### Auto Final Merge Workflow
- **New workflow file**: `.github/workflows/auto-final-merge.yml`
- **Trigger**: `final-*` タグ作成時に自動実行
- **Safety checks**: 承認済みPRの存在確認
- **Auto-merge**: mainブランチへの自動マージ
- **Release creation**: GitHub Release自動作成

#### Student Documentation Updates

**README.md**
- **2-stage process**: 論文提出許可 → 概要執筆の明確な分離
- **Tag semantics**: submit tag (提出許可) の説明
- **Simplified operations**: コマンドライン操作を削除、GitHub Desktop のみ
- **Phase limitation**: Phase 3 は口頭説明として除外

**WRITING-GUIDE.md**  
- **Detailed 2-stage guidance**: submit tag → 概要執筆の詳細手順
- **GitHub Desktop focus**: すべてのGit操作をGUI化
- **PDF generation**: VS Code ボタン操作のみ (latexmk コマンド削除)
- **Clear boundaries**: 概要完成まで = 学生ドキュメントの範囲

### Workflow Details

```yaml
final-* tag creation → 
  Approved PR detection → 
    Auto merge to main → 
      GitHub Release creation → 
        Submission complete
```

### Benefits for Students

- **Simplified operations**: GitHub Desktop + VS Code のみ
- **Clear milestones**: submit tag で明確な区切り
- **Reduced complexity**: コマンドライン学習不要
- **Automatic final submission**: タグ作成のみで完了

### Benefits for Faculty  

- **Staged review process**: 論文本体 → 概要 → 最終版の段階的管理
- **Clear approval points**: submit vs final の明確な区別
- **Automated workflow**: 最終承認後の手動作業排除
- **Complete audit trail**: 全提出過程の記録保持

## Test plan

- [x] Verify auto-merge workflow triggers correctly on final-* tags
- [x] Confirm safety checks prevent unauthorized merges
- [x] Validate student documentation covers Phase 1-2 appropriately
- [x] Test GitHub Desktop-only operations work smoothly
- [x] Check PDF generation via VS Code buttons functions properly