### PR TITLE
Update setup.sh command to use positional argument syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ VS Code devContainer を用いて、LaTeX 処理系、および textlint を内�
 
 **スクリプトでリポジトリを作成：**
 ```bash
-DOC_TYPE=thesis /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash thesis
 ```
 
 **実行手順**：


### PR DESCRIPTION
## Summary

Update README.md to reflect the new positional argument syntax for setup.sh introduced in thesis-management-tools#351.

## Changes

- Update setup command from environment variable style to positional argument style
- Old: `DOC_TYPE=thesis /bin/bash -c "$(curl -fsSL URL)"`
- New: `/bin/bash -c "$(curl -fsSL URL)" bash thesis`

## Related

- thesis-management-tools#350
- thesis-management-tools#351