### PR TITLE
Upgrade latex-release-action to v3.0.0

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   build-and-release-pdf:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
     steps:
-      - uses: smkwlab/latex-release-action@v2.5.0
+      - uses: actions/checkout@v4
+      - uses: smkwlab/latex-release-action@v3.0.0
         with:
           files: sotsuron, gaiyou, thesis, abstract


### PR DESCRIPTION
## Summary

Migrates to latex-release-action v3.0.0, which provides centralized TeXLive version management through Docker Container Action architecture.

## Changes

### Workflow Updates (.github/workflows/latex-build.yml)
- **Removed**: `container: ghcr.io/smkwlab/texlive-ja-textlint:2025g` specification
- **Added**: Explicit `actions/checkout@v4` step (required for Docker Container Actions)
- **Updated**: Action version from `@v2.5.0` to `@v3.0.0`

### Before
```yaml
jobs:
  build-and-release-pdf:
    runs-on: ubuntu-latest
    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
    steps:
      - uses: smkwlab/latex-release-action@v2.5.0
        with:
          files: sotsuron, gaiyou, thesis, abstract
```

### After
```yaml
jobs:
  build-and-release-pdf:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: smkwlab/latex-release-action@v3.0.0
        with:
          files: sotsuron, gaiyou, thesis, abstract
```

## Benefits

### Centralized Version Management
- **No more manual updates**: TeXLive version (now 2025i) is managed by the action
- **Automatic upgrades**: Bump action version to get latest TeXLive
- **Consistency**: All repositories use the same LaTeX environment

### Simplified Workflow
- **Cleaner YAML**: No container specification needed
- **Standard pattern**: Matches typical GitHub Actions usage

## Testing

- [ ] Workflow runs successfully
- [ ] PDF files are generated correctly
- [ ] GitHub Release is created properly

## Related

- latex-release-action v3.0.0: https://github.com/smkwlab/latex-release-action/releases/tag/v3.0.0
- Original issue: smkwlab/latex-release-action#31