### PR TITLE
Update latex-release-action to v3.0.1

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: smkwlab/latex-release-action@v3.0.0
+      - uses: smkwlab/latex-release-action@v3.0.1
         with:
           files: sotsuron, gaiyou, thesis, abstract


### PR DESCRIPTION
## Summary

Updates latex-release-action from v3.0.0 to v3.0.1 to fix Alpine Linux compatibility issue.

## Issue with v3.0.0

v3.0.0 had a critical bug that caused build failures on GitHub Actions:
- Used Debian commands (`apt-get`) 
- GitHub Actions uses Alpine Linux base image
- Result: All builds failed with `apt-get: not found`

## Changes

```yaml
# Before
- uses: smkwlab/latex-release-action@v3.0.0

# After  
- uses: smkwlab/latex-release-action@v3.0.1
```

## What's Fixed in v3.0.1

- ✅ Alpine Linux compatibility restored
- ✅ GitHub CLI installation works correctly
- ✅ PDF builds succeed on GitHub Actions

## Related

- v3.0.1 Release: https://github.com/smkwlab/latex-release-action/releases/tag/v3.0.1
- Fix PR: https://github.com/smkwlab/latex-release-action/pull/33