### PR TITLE
Update latex-release-action to v3.0.2

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: smkwlab/latex-release-action@v3.0.1
+      - uses: smkwlab/latex-release-action@v3.0.2
         with:
           files: sotsuron, gaiyou, thesis, abstract


### PR DESCRIPTION
Fixes GitHub Release creation failure in v3.0.1.

v3.0.2 adds GH_TOKEN environment variable to fix gh CLI authentication.

Related: https://github.com/smkwlab/latex-release-action/pull/34