### PR TITLE
Update to latex-release-action v3.0.3 with GH_TOKEN env

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: smkwlab/latex-release-action@v3.0.2
+      - uses: smkwlab/latex-release-action@v3.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           files: sotsuron, gaiyou, thesis, abstract


### PR DESCRIPTION
Updates latex-release-action to v3.0.3 and adds required `GH_TOKEN` environment variable.

## Changes
- Update action version from v3.0.2 to v3.0.3
- Add `env: GH_TOKEN: ${{ github.token }}` to workflow

## Background
v3.0.3 fixes a critical bug where Docker Container Actions cannot use GitHub context expressions in `action.yml` env section. Users must now set `GH_TOKEN` in their workflow files.

Related: smkwlab/latex-release-action#35, smkwlab/latex-release-action#36