### PR TITLE
Update to latex-release-action v3.0.4

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: smkwlab/latex-release-action@v3.0.3
+      - uses: smkwlab/latex-release-action@v3.0.4
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Updates latex-release-action to v3.0.4 to fix GitHub Release creation error.

## Changes
- Update action version from v3.0.3 to v3.0.4

## What's Fixed
v3.0.4 fixes git safe.directory error that prevented GitHub Release creation:
```
fatal: detected dubious ownership in repository at '/github/workspace'
```

Related: smkwlab/latex-release-action#37