### PR TITLE
Update latex-release-action to v3.1.0

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: smkwlab/latex-release-action@v3.0.4
+      - uses: smkwlab/latex-release-action@v3.1.0
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

Updates latex-release-action from v3.0.4 to v3.1.0.

## Changes

- Bump latex-release-action version: v3.0.4 → v3.1.0

## v3.1.0 Improvements

- Release notes now use GitHub's auto-generated format with "What's Changed" and "Full Changelog"
- Removed technical build details from release notes (Build options, Parallel build, Cleanup)
- Better user experience for students viewing release notes

## Related

- Release: https://github.com/smkwlab/latex-release-action/releases/tag/v3.1.0
- CHANGELOG: https://github.com/smkwlab/latex-release-action/blob/main/CHANGELOG.md