### PR TITLE
Add GitHub CLI prerequisites and installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,71 @@ VS Code devContainer を用いて、LaTeX 処理系、および textlint を内�
 
 ### 1. リポジトリの作成
 
-**前提条件**: Docker Desktop と GitHub Desktop がインストール済み。
+#### 前提条件
 
-**スクリプトでリポジトリを作成：**
+以下のソフトウェアがインストール済みであること：
+
+1. **Docker Desktop** - LaTeX 環境の実行に必要
+2. **GitHub Desktop** - リポジトリ管理・同期に必要
+3. **GitHub CLI (gh)** - リポジトリ作成スクリプトの実行に必要
+
+#### GitHub CLI のインストール
+
+**macOS:**
+```bash
+brew install gh
+```
+
+**Windows (WSL):**
+```bash
+# WSL 内で実行
+sudo mkdir -p -m 755 /etc/apt/keyrings
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh
+```
+
+**注意:** Windows では WSL 内で全ての操作を実行してください。
+
+**インストール確認:**
+```bash
+gh --version
+```
+
+#### GitHub 認証
+
+リポジトリ作成スクリプト実行前に、GitHub CLI で認証を完了しておく：
+
+```bash
+gh auth login
+```
+
+**認証手順:**
+1. `GitHub.com` を選択
+2. `HTTPS` を選択
+3. `Login with a web browser` を選択
+4. 表示されたワンタイムコードをコピー
+5. ブラウザが自動で開くので、コードを入力して認証完了
+
+**認証確認:**
+```bash
+gh auth status
+```
+
+#### スクリプトでリポジトリを作成
+
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash thesis
 ```
 
-**実行手順**：
-1. 上記コマンドを実行
-2. GitHub認証：ワンタイムコードをブラウザで入力
-3. 学籍番号を入力
-4. 自動でリポジトリ作成・セットアップ完了
+**実行手順:**
+1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）
+2. 学籍番号を入力
+3. 自動でリポジトリ作成・セットアップ完了
+
+**注意:** GitHub 認証は事前に `gh auth login` で完了済みであること。
 
 ### 2. 論文執筆の開始
 


### PR DESCRIPTION
## Summary

Fixes #97

README.md に GitHub CLI (gh) の前提条件とインストール・認証手順を追加しました。

## Changes

### 前提条件セクションの更新
- GitHub CLI (gh) を必須ソフトウェアとして明記
- Docker Desktop、GitHub Desktop と並べて記載

### GitHub CLI インストール手順の追加
- **macOS**: Homebrew を使用 (`brew install gh`)
- **Windows (WSL)**: 公式リポジトリセットアップ手順を詳細に記載
- Git Bash の手順は削除（Docker Desktop が WSL2 を必要とするため、WSL で統一）

### GitHub 認証手順の追加
- `gh auth login` の実行手順を詳細に説明
- 認証フロー（GitHub.com → HTTPS → ブラウザ認証）を記載
- `gh auth status` で認証確認する手順を追加

### 実行手順の明確化
- setup.sh 実行前に `gh auth login` が完了済みであることを明記
- macOS ターミナルまたは WSL 内での実行を明示

## Technical Details

- setup.sh (thesis-management-tools) は `gh auth token` でトークンを取得するため、実行環境で gh 認証が必須
- Windows では WSL 環境が必要（Docker Desktop が WSL2 を使用するため）
- 各環境で独立して認証が必要（Windows ネイティブの認証は WSL からアクセス不可）

## Test Plan

- [ ] macOS での手順が正しく動作することを確認
- [ ] WSL での手順が正しく動作することを確認
- [ ] 学生が手順通りに実行できることを確認