### PR TITLE
Add workflow to notify lab ML on PR creation

### DIFF
--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -1,0 +1,44 @@
+name: Notify Lab ML on PR
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  notify-ml:
+    # draft PRの場合はスキップ
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract student info from repository name
+        id: repo-info
+        run: |
+          # リポジトリ名から学籍番号を抽出（例: k21rs001-sotsuron → k21rs001）
+          REPO_NAME="${{ github.event.repository.name }}"
+          STUDENT_ID=$(echo $REPO_NAME | grep -oE '^k[0-9]{2}[a-z]{2,3}[0-9]{2,3}')
+          echo "student_id=$STUDENT_ID" >> $GITHUB_OUTPUT
+
+      - name: Send notification email to lab ML
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.SMTP_SERVER }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "[PR] ${{ github.event.repository.name }}: ${{ github.event.pull_request.title }}"
+          to: ${{ secrets.LAB_ML_ADDRESS }}
+          from: ${{ secrets.SMTP_FROM }}
+          content_type: text/html
+          body: |
+            <h2>新しいPull Requestが作成されました</h2>
+
+            <p><strong>学生:</strong> ${{ steps.repo-info.outputs.student_id }} (${{ github.event.pull_request.user.login }})</p>
+            <p><strong>リポジトリ:</strong> ${{ github.event.repository.name }}</p>
+            <p><strong>タイトル:</strong> ${{ github.event.pull_request.title }}</p>
+            <p><strong>ブランチ:</strong> ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}</p>
+
+            <p><a href="${{ github.event.pull_request.html_url }}">PRを確認する</a></p>
+
+            <hr>
+            <p><small>このメールはGitHub Actionsから自動送信されています</small></p>


### PR DESCRIPTION
## Summary

PR作成時に研究室のMLに自動通知を送信するワークフローを追加します。

## 目的

- 学生がPRを作成した際、assignされていない研究室メンバーにも通知
- 研究室のメーリングリストに自動的にメール送信

## 実装内容

### 新規ファイル
- \`.github/workflows/notify-ml-on-pr.yml\`

### ワークフローの動作
1. **トリガー**: PR作成時 (\`opened\`) または draft → ready for review 時
2. **条件**: draft PRは除外（ready for reviewで通知）
3. **通知内容**:
   - 学生の学籍番号とGitHubユーザー名
   - リポジトリ名
   - PRタイトル
   - ブランチ情報
   - PR URL

### メール設定
Organization Secretsを使用（各リポジトリへの認証情報配布不要）:
- \`SMTP_SERVER\`: smtp.gmail.com
- \`SMTP_PORT\`: 587
- \`SMTP_USERNAME\`: 研究室共用アカウント
- \`SMTP_PASSWORD\`: Googleアプリパスワード
- \`LAB_ML_ADDRESS\`: 研究室MLアドレス
- \`SMTP_FROM\`: 送信元アドレス

## 汎用性

件名を \`[PR] リポジトリ名: タイトル\` とすることで、他のテンプレート（週報、ISEレポート、ポスター等）にも適用可能。

## テスト

このPR自体で動作確認可能（PRがopenedイベントで発火）。