### PR TITLE
Fix incorrect secrets usage in ML notification workflow

### DIFF
--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -27,7 +27,7 @@ jobs:
           echo "For users outside the organization: you can safely delete this workflow file if not needed"
 
       - name: Send notification email to lab ML
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7  # v3
         with:
           server_address: ${{ secrets.SMTP_SERVER }}
           server_port: ${{ secrets.SMTP_PORT }}


### PR DESCRIPTION
ML通知ワークフローの誤ったSecrets使用方法を修正しました。

## 問題点

PR #102 でマージされたコードに問題がありました：

\`\`\`yaml
if: \${{ !github.event.pull_request.draft && secrets.SMTP_SERVER }}
\`\`\`

GitHub Actions では \`secrets\` を \`if\` 条件内で直接参照できません。[公式ドキュメント](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)でも明記されています。

## 修正内容

### 1. if 条件の修正

\`\`\`yaml
# Before
if: \${{ !github.event.pull_request.draft && secrets.SMTP_SERVER }}

# After  
if: \${{ !github.event.pull_request.draft }}
\`\`\`

### 2. ドキュメントとログの追加

- **インラインコメント**: 必要なSecretsとガイダンスを記載
- **チェックステップ**: 実行ログに要件を出力

\`\`\`yaml
steps:
  - name: Check requirements
    run: |
      echo "::notice::ML notification workflow requires Organization Secrets"
      echo "Required secrets: SMTP_SERVER, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD, LAB_ML_ADDRESS, SMTP_FROM"
      echo "If this workflow fails due to missing secrets, please check your organization settings"
      echo "For users outside the organization: you can safely delete this workflow file if not needed"
\`\`\`

## 影響範囲

- 組織内: 変更なし（Secretsチェックは機能していなかったため）
- 組織外: エラーメッセージが改善され、対処方法が明確に

## 関連Issue

- smkwlab/ise-report-template#65 - Copilotレビューで同じ問題を指摘