### PR TITLE
Enhance ML notification email with PR details

### DIFF
--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -26,6 +26,33 @@ jobs:
           echo "If this workflow fails due to missing secrets, please check your organization settings"
           echo "For users outside the organization: you can safely delete this workflow file if not needed"
 
+      - name: Get PR details
+        id: pr_details
+        run: |
+          # コミット一覧を取得（最大10件）
+          COMMITS=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json commits \
+            --jq '.commits[] | "  * \(.messageHeadline)"' | head -10)
+
+          # ファイル変更一覧を取得（最大20件）
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files \
+            --jq '.files[] | "  * \(.path) (+\(.additions)/-\(.deletions))"' | head -20)
+
+          # 複数行を環境変数に設定
+          {
+            echo "COMMITS<<EOF"
+            echo "$COMMITS"
+            echo "EOF"
+            echo "FILES<<EOF"
+            echo "$FILES"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Send notification email to lab ML
         uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7  # v3
         with:
@@ -36,7 +63,6 @@ jobs:
           subject: "[PR] ${{ github.event.repository.name }}: ${{ github.event.pull_request.title }}"
           to: ${{ secrets.LAB_ML_ADDRESS }}
           from: ${{ secrets.SMTP_FROM }}
-          content_type: text/plain
           body: |
             新しいPull Requestが作成されました
 
@@ -45,7 +71,25 @@ jobs:
             タイトル: ${{ github.event.pull_request.title }}
             ブランチ: ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}
 
-            PR URL: ${{ github.event.pull_request.html_url }}
+            説明:
+            ${{ github.event.pull_request.body || '(No description provided)' }}
+
+            You can view, comment on, or merge this pull request online at:
+
+              ${{ github.event.pull_request.html_url }}
+
+            -- Commit Summary --
+
+            ${{ steps.pr_details.outputs.COMMITS || '  (No commits available)' }}
+
+            -- File Changes --
+
+            ${{ steps.pr_details.outputs.FILES || '  (No files available)' }}
+
+            -- Patch Links --
+
+            ${{ github.event.pull_request.patch_url }}
+            ${{ github.event.pull_request.diff_url }}
 
             ---
             このメールはGitHub Actionsから自動送信されています


### PR DESCRIPTION
## Summary

ML通知メールにPRの詳細情報を追加しました。

## Changes

通知メールに以下の情報を追加：
- PR本文/説明（空の場合はフォールバックテキスト）
- コミット一覧（最大10件、空の場合はフォールバックテキスト）
- ファイル変更一覧（追加/削除行数付き、最大20件、空の場合はフォールバックテキスト）
- パッチとdiffのダウンロードリンク
- インデントを2スペースに統一
- PR本文に「説明:」ラベルを追加

## Technical Details

- `gh pr view` コマンドでPR詳細を取得
- jqフィルタでフォーマット整形
- GITHUB_OUTPUTで複数行環境変数を保存
- メール本文にPR詳細を組み込み
- フォールバックテキストで空の値に対応

## Testing

k19rs999-sotsuronリポジトリでテスト済み（PR #4）

## Related Issues

latex-template, poster-template, ise-report-templateにも同様の更新を適用済み