### PR TITLE
Fix workflow trigger to support draft-to-draft PRs

### DIFF
--- a/.github/workflows/create-next-draft.yml
+++ b/.github/workflows/create-next-draft.yml
@@ -4,8 +4,7 @@ name: Create Next Draft Branch
 on:
   pull_request:
     types: [opened]
-    branches:
-      - main
+    # No branch filter: allow PRs to any branch (draft/abstract filtering done in job condition)
 
 jobs:
   create-next-branch:


### PR DESCRIPTION
Resolves smkwlab/latex-ecosystem#60

## 問題

現在の \`create-next-draft.yml\` workflow は main への PR のみをトリガーするため、2nd-draft 以降のブランチが自動作成されない。

```yaml
on:
  pull_request:
    types: [opened]
    branches:
      - main  # ← これが問題
```

**影響:**
- 1st-draft → main への PR → 2nd-draft 作成 ✅
- 2nd-draft → 1st-draft への PR → 3rd-draft 作成 ❌ トリガーされない
- 3rd-draft → 2nd-draft への PR → 4th-draft 作成 ❌ トリガーされない

## 修正内容

\`branches\` フィルターを削除し、任意のブランチへの PR でトリガーするように変更。

```yaml
on:
  pull_request:
    types: [opened]
    # No branch filter: allow PRs to any branch
```

**安全性:**
- draft/abstract ブランチかどうかの判定は既存の \`if\` 条件で実施（line 15-17）
- 不要な PR に対しては job がスキップされるため問題なし

## テスト

修正後の動作:
- 1st-draft → main への PR → 2nd-draft 作成 ✅
- 2nd-draft → 1st-draft への PR → 3rd-draft 作成 ✅ 修正により動作
- 3rd-draft → 2nd-draft への PR → 4th-draft 作成 ✅ 修正により動作
- abstract-1st → 5th-draft への PR → abstract-2nd 作成 ✅
- 無関係な PR → スキップ ✅ if 条件により安全

## 関連 Issue

- smkwlab/latex-ecosystem#59 - ドキュメントを元の設計に修正
- smkwlab/latex-ecosystem#60 - workflow を元の設計に対応