### PR TITLE
Fix prevent-draft-merge to trigger on all draft PRs

### DIFF
--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -4,9 +4,8 @@ name: Prevent Draft Merge
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - review-branch
+    # All draft PRs should be protected, not just PRs to main/review-branch
+    # The reusable workflow checks if the head branch is a draft pattern
 
 jobs:
   prevent-merge:


### PR DESCRIPTION
## Summary

Remove \`branches\` filter from prevent-draft-merge.yml so that the workflow triggers on all PRs, not just PRs targeting main/review-branch.

## Problem

Previously, draft-to-draft PRs (e.g., \`4th-draft -> 3rd-draft\`) were not protected from accidental merges because the workflow only triggered on PRs to \`main\` or \`review-branch\`.

## Solution

Remove the \`branches\` filter. The reusable workflow already checks if the head branch matches a draft pattern, so no additional filtering is needed in the caller workflow.

## Impact

All draft PRs will now show the "Prevent Draft Merge" check as failed, clearly indicating to students that these PRs are for review only and should not be merged.