### PR TITLE
Add 'final' tag trigger to auto-final-merge workflow

### DIFF
--- a/.github/workflows/auto-final-merge.yml
+++ b/.github/workflows/auto-final-merge.yml
@@ -4,6 +4,7 @@ name: Auto Final Merge
 on:
   push:
     tags:
+      - 'final'
       - 'final-*'
 
 jobs:


### PR DESCRIPTION
## Summary
- `final` タグでも auto-final-merge ワークフローがトリガーされるように変更
- 既存の `final-*` パターンに加えて `final` 単体もサポート

## Related
- smkwlab/.github#16 の修正に対応