### PR TITLE
Unify .latexmkrc: upmendex and -halt-on-error

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,5 +1,5 @@
-$latex = 'uplatex -synctex=1 -file-line-error -interaction=nonstopmode';
+$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
 $bibtex = 'upbibtex';
 $dvipdf = 'dvipdfmx %O -o %D %S';
-$makeindex = 'mendex -U %O -o %D %S';
-$pdf_mode = 3; 
+$makeindex = 'upmendex %O -o %D %S';
+$pdf_mode = 3;


### PR DESCRIPTION
## 概要

エコシステム全体の `.latexmkrc` 統一の一環です。

## 変更内容

| 項目 | Before | After |
|---|---|---|
| makeindex | `mendex -U` | **`upmendex`**（uplatex の Unicode 内部表現に適合） |
| オプション | `-synctex=1 -file-line-error -interaction=nonstopmode` | `-synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode` |

```perl
$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
$bibtex = 'upbibtex';
$dvipdf = 'dvipdfmx %O -o %D %S';
$makeindex = 'upmendex %O -o %D %S';
$pdf_mode = 3;
```

## 補足

- `-halt-on-error` を追加し、最初のエラーで停止させることで原因特定を容易にします（`-interaction=nonstopmode` と併用しCIでのプロンプト停止も防止）。
- `-interaction=nonstopmode` の CI 側との二重指定回避は共有ワークフロー `smkwlab/.github` の改修が必要なため、別途対応します。