### PR TITLE
ci: add Claude Code Review caller

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,23 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing every push
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: opus
+      review_language: 日本語


### PR DESCRIPTION
Adds the shared Claude Code Review workflow as a caller of
`smkwlab/.github/.github/workflows/claude-code-review.yml@v1` (model: `opus`).

PR への自動レビュー（Claude）を有効化します。

- draft はスキップ（`ready_for_review` で起動）
- fork PR では secret が渡らないため安全にスキップ
- 動作には org シークレット `ANTHROPIC_API_KEY` がこのリポジトリで利用可能である必要があります