### PR TITLE
ci: add claude-mention caller

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,33 @@
+# Caller template: Claude Mention (interactive @claude handler).
+# Distributed by scripts/distribute-workflow.sh as
+# .github/workflows/claude-mention.yml in each target repository.
+# The ref / model / language tokens below are substituted at distribution time.
+name: Claude Mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude:
+    # Run only when @claude is mentioned AND the author has repository access
+    # (OWNER/MEMBER/COLLABORATOR), so external users cannot trigger a write run.
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    uses: smkwlab/.github/.github/workflows/claude-mention.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: opus
+      language: 日本語


### PR DESCRIPTION
Adds the shared `claude-mention` workflow as a caller of `smkwlab/.github/.github/workflows/claude-mention.yml@v1`.

`@claude` メンションでの対話・修正依頼を有効化します。

- 動作には org シークレット `ANTHROPIC_API_KEY` がこのリポジトリで利用可能である必要があります（未配布なら安全にスキップ）
- 起動するのは権限保有者（OWNER / MEMBER / COLLABORATOR）のコメントのみです