### PR TITLE
feat: auto-sync accepted suggestions into the next draft branch

### DIFF
--- a/.github/workflows/sync-next-draft.yml
+++ b/.github/workflows/sync-next-draft.yml
@@ -1,0 +1,14 @@
+name: Sync Suggestions to Next Draft
+
+on:
+  push:
+    branches:
+      - '*-draft'
+      - 'abstract-*'
+
+jobs:
+  sync:
+    permissions:
+      contents: write        # 次稿ブランチへの merge push に必要
+      pull-requests: write   # コンフリクト時の同期 PR 作成に必要
+    uses: smkwlab/.github/.github/workflows/sync-next-draft.yml@v1

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -37,6 +37,7 @@ abstract-2nd → PR (base: abstract-1st, 前回からの差分のみ) → レビ
 - **作業ブランチ**: 各 draft PR は直前の draft をベースとする（前回からの差分のみを表示）
 - **教員フィードバック**: PR で GitHub のコメントと suggestion 機能を使用
 - **次のドラフト**: PR 作成後に自動的に次のブランチが作成される
+- **suggestion の反映**: suggestion を受け入れると、その修正は自動的に次の draft ブランチへも merge される（sync-next-draft）。手元の作業ブランチには `git pull` で取り込む。自動 merge がコンフリクトした場合は同期 PR が自動作成されるので、ブラウザの「Resolve conflicts」で解決してからその同期 PR を merge する（同期 PR は merge してよい）
 - **PR の扱い**: PR はマージせず、レビュー完了後にクローズして次稿へ継続
 
 ## LaTeX コンパイル例
@@ -97,4 +98,3 @@ textlint abstract.tex         # 大学院生概要
 textlint example.tex
 textlint example-gaiyou.tex
 ```
-


### PR DESCRIPTION
## 概要

レビュー PR で受け入れた suggestion が次稿ブランチに反映されない問題 (#110) を自動化で解決します。

## 変更内容

- **新規 `.github/workflows/sync-next-draft.yml`**: draft ブランチへの push をトリガーに、再利用ワークフロー `smkwlab/.github/.github/workflows/sync-next-draft.yml@v1` (v1.25.1) を呼び出す caller。suggestion 受け入れなどの push が後続 draft ブランチへ連鎖的に自動 merge される。コンフリクト時は前稿→次稿の同期 PR が自動作成され、ブラウザの「Resolve conflicts」で解決できる
- **docs/CLAUDE-WORKFLOWS.md**: 「ブランチ管理」に suggestion 自動反映とコンフリクト時の対応手順を追記

## 挙動

- `1st-draft` で suggestion 受け入れ → 数十秒後に `2nd-draft` (存在すれば `3rd-draft` 以降も) へ自動 merge
- 学生は次の執筆再開時に `git pull` するだけ
- 成功時の PR コメントは出さない (ノイズ回避、Actions の step summary に記録)

## 備考

- `push` トリガーは push されたブランチ上のワークフローファイルを参照するため、このテンプレート更新は**以降に作成される新規リポジトリ**に有効。既存の学生リポジトリへは別途配布する (今年度は ise-report1 群のみ対象)
- 手動スクリプト案の #111 は本 PR の merge 後にクローズ予定

Closes #110