### PR TITLE
docs: adopt the draft PR cycle terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
 ### 2. 論文執筆の開始
 
 作成されたリポジトリで執筆を開始する。
-下川研以外の学生は、以下の手順2以降で自由に論文を執筆する。「3. Pull Request による添削システム」で説明している `0th-draftブランチ`は存在しないため無視すること。
+下川研以外の学生は、以下の手順2以降で自由に論文を執筆する。「3. 論文執筆の流れ（draft PR サイクル）」で説明している `0th-draftブランチ`は存在しないため無視すること。
 下川研の学生は、手順3以降のルールにしたがって執筆すること。
 
 1. **GitHub Desktop でリポジトリをクローン**
@@ -59,7 +59,9 @@ bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
    - GitHub Desktop で `Current Branch` → `0th-draft` を選択
    - 以降も、提出後は自動で作成されるブランチ（1st-draft等）を選択
 
-### 3. 論文執筆の流れ
+### 3. 論文執筆の流れ（draft PR サイクル）
+
+draft ブランチで執筆し、Pull Request で添削を受け、自動作成される次の稿のブランチで改稿を続ける繰り返しを **draft PR サイクル**と呼びます。
 
 ```
 0th-draft: 目次案作成・提出
@@ -74,6 +76,10 @@ abstract-1st: 概要執筆・提出
 ```
 
 **重要**: PRは教員による添削・フィードバック用です。レビューへの対応完了後は**自分でPRをクローズ**し、次の執筆を続けること。
+
+> この draft PR サイクル（PR はマージせずクローズ・次稿ブランチ自動作成などの共通ルール）の全体像は
+> [STUDENT-WORKFLOW.md](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/STUDENT-WORKFLOW.md)
+> にまとまっています。本 README は卒業論文・修士論文固有の手順を説明します。
 
 ### 4. 詳細な操作手順
 

--- a/WRITING-GUIDE.md
+++ b/WRITING-GUIDE.md
@@ -44,7 +44,7 @@ bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
 - `thesis.tex` - 論文本体  
 - `abstract.tex` - 概要
 
-## 基本的な流れ
+## 基本的な流れ（draft PR サイクル）
 
 1. **リポジトリをPCにクローン**
 2. **0th-draft ブランチで目次案を作成・提出**
@@ -53,6 +53,10 @@ bash <(curl -fsSL https://repo-setup.smkwlab.net) thesis
 5. **自動作成された 2nd-draft ブランチで第2稿を執筆**
 6. **3稿目以降も同様に繰り返し（次稿ブランチは自動作成）**
 7. **教員の指示で概要執筆開始**（論文本体がある程度完成した段階）
+
+> この 2〜6 の繰り返しが **draft PR サイクル**です。共通ルール（PR はマージせずクローズ・次稿ブランチ自動作成など）の全体像は
+> [STUDENT-WORKFLOW.md](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/STUDENT-WORKFLOW.md)
+> にまとまっています。
 
 ## 詳細な操作手順
 


### PR DESCRIPTION
## 概要

smkwlab/latex-ecosystem#137 の対応 1。旗艦テンプレートである本リポジトリだけが、ise / poster / latex が揃って使う共通用語「**draft PR サイクル**」と STUDENT-WORKFLOW.md へのリンクを持っていなかったため、他テンプレートと同型に揃えます。

## 変更内容

- README: セクション 3 を「論文執筆の流れ（draft PR サイクル）」に改題し、冒頭に一文定義を追加。図の後に STUDENT-WORKFLOW.md への標準の案内(ise/poster/latex と同型)を追加
- README: 存在しない旧見出し「3. Pull Request による添削システム」への stale reference を現見出しに修正
- WRITING-GUIDE: 「基本的な流れ（draft PR サイクル）」に改題し、手順 2〜6 の繰り返しがこの用語の指す内容であることと STUDENT-WORKFLOW.md への案内を追加

見出しへのアンカー参照がないことは確認済みです。

## 関連

- smkwlab/latex-ecosystem#137(用語集の作成は latex-ecosystem 側の別 PR で続きます)