### PR TITLE
docs: drop the leftover "# Test" heading from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,3 @@ def hello_world():
 - [student-repo-management](https://github.com/smkwlab/student-repo-management) - 詳細ガイド・教員向けツール
 
 **質問・サポート**: smkwlabML または担当教員まで。
-# Test


### PR DESCRIPTION
## 概要

root `README.md` の末尾に残っていた `# Test` という見出しを削除します。

学生リポジトリのトップページに表示されていた残骸です（#136 の作業中に発見）。

## 補足: Actions 設定変更の動作確認を兼ねます

このリポジトリは Actions がリポジトリ単位で無効化されており、テンプレートの `.tex` / `.sty` / `.latexmkrc` を変更しても LaTeX ビルドが検証されない状態でした。壊れたテンプレートはその後に作成される全学生リポジトリへ配布されるため、`Build and Release PDF` のみ動くよう設定を変更しています。

- リポジトリの Actions を有効化
- draft PR サイクル前提で、テンプレートリポジトリ上では意味を持たないワークフローを個別に無効化
  - `Create Next Draft Branch` / `Auto Final Merge` / `Prevent Draft Merge` / `Sync Suggestions to Next Draft` — draft ブランチ階層が存在しない
  - `Notify Lab ML on PR` — テンプレート更新の PR を研究室 ML に流す必要がない
  - `AI Paper Review` — 雛形の `.tex` を論文としてレビューする価値が薄く、更新のたびに課金される
  - `Claude QA`
- `Dependabot Updates` は有効のまま残しています。学生リポジトリでは `.github/dependabot.yml` を削除する設計（#514）である以上、ワークフロー参照の更新経路はテンプレート側にしかないためです

この PR で `Build and Release PDF` のみが起動することを確認します。
